### PR TITLE
Edit StorageClassDiagram to fit context of InternBook

### DIFF
--- a/docs/diagrams/StorageClassDiagram.puml
+++ b/docs/diagrams/StorageClassDiagram.puml
@@ -14,11 +14,11 @@ Class JsonUserPrefsStorage
 Class "<<interface>>\nStorage" as Storage
 Class StorageManager
 
-package "AddressBook Storage" #F4F6F6{
-Class "<<interface>>\nAddressBookStorage" as AddressBookStorage
-Class JsonAddressBookStorage
-Class JsonSerializableAddressBook
-Class JsonAdaptedPerson
+package "InternBook Storage" #F4F6F6{
+Class "<<interface>>\nInternBookStorage" as InternBookStorage
+Class JsonInternBookStorage
+Class JsonSerializableInternBook
+Class JsonAdaptedCompany
 Class JsonAdaptedTag
 }
 
@@ -29,15 +29,15 @@ HiddenOutside ..> Storage
 
 StorageManager .up.|> Storage
 StorageManager -up-> "1" UserPrefsStorage
-StorageManager -up-> "1" AddressBookStorage
+StorageManager -up-> "1" InternBookStorage
 
 Storage -left-|> UserPrefsStorage
-Storage -right-|> AddressBookStorage
+Storage -right-|> InternBookStorage
 
 JsonUserPrefsStorage .up.|> UserPrefsStorage
-JsonAddressBookStorage .up.|> AddressBookStorage
-JsonAddressBookStorage ..> JsonSerializableAddressBook
-JsonSerializableAddressBook --> "*" JsonAdaptedPerson
-JsonAdaptedPerson --> "*" JsonAdaptedTag
+JsonInternBookStorage .up.|> InternBookStorage
+JsonInternBookStorage ..> JsonSerializableInternBook
+JsonSerializableInternBook --> "*" JsonAdaptedCompany
+JsonAdaptedCompany --> "*" JsonAdaptedTag
 
 @enduml


### PR DESCRIPTION
Edit the StorageClassDiagram to match the context of InternBook, such as changing the instances of Person to Company, and instances of AddressBook to InternBook