### PR TITLE
Edit the help command to display the user guide instantly

### DIFF
--- a/src/main/java/seedu/address/ui/HelpWindow.java
+++ b/src/main/java/seedu/address/ui/HelpWindow.java
@@ -113,9 +113,10 @@ public class HelpWindow extends UiPart<Stage> {
     /**
      * Opens the user guide in web view.
      */
-    @FXML
-    private void openUserGuide() {
-        getRoot().setScene(new Scene(webView, 800, 600));
+    public void openUserGuide() {
+        if (webView.getScene() == null) {
+            getRoot().setScene(new Scene(webView, 800, 600));
+        }
         getRoot().show();
     }
 }

--- a/src/main/java/seedu/address/ui/MainWindow.java
+++ b/src/main/java/seedu/address/ui/MainWindow.java
@@ -141,7 +141,7 @@ public class MainWindow extends UiPart<Stage> {
     @FXML
     public void handleHelp() {
         if (!helpWindow.isShowing()) {
-            helpWindow.show();
+            helpWindow.openUserGuide();
         } else {
             helpWindow.focus();
         }


### PR DESCRIPTION
Made some minor changes so that the help command displays the user guide instantly instead of a window where the user have to choose between copying the url or opening the URL making it a two step process. 

Now it launches the user guide whenever the help command is entered.